### PR TITLE
Avoid using pointers to store opaque values, which will be incompatible in Go 1.4

### DIFF
--- a/input.go
+++ b/input.go
@@ -29,7 +29,6 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 type forwardClient struct {
@@ -52,7 +51,7 @@ type ForwardInput struct {
 	wg             sync.WaitGroup
 	acceptChan     chan *net.TCPConn
 	shutdownChan   chan struct{}
-	isShuttingDown unsafe.Pointer
+	isShuttingDown uintptr
 }
 
 type EntryCountTopic struct{}
@@ -317,7 +316,7 @@ func (input *ForwardInput) WaitForShutdown() {
 }
 
 func (input *ForwardInput) Stop() {
-	if atomic.CompareAndSwapPointer(&input.isShuttingDown, unsafe.Pointer(uintptr(0)), unsafe.Pointer(uintptr(1))) {
+	if atomic.CompareAndSwapUintptr(&input.isShuttingDown, uintptr(0), uintptr(1)) {
 		input.shutdownChan <- struct{}{}
 	}
 }
@@ -348,6 +347,6 @@ func NewForwardInput(logger *logging.Logger, bind string, port Port) (*ForwardIn
 		wg:             sync.WaitGroup{},
 		acceptChan:     make(chan *net.TCPConn),
 		shutdownChan:   make(chan struct{}),
-		isShuttingDown: unsafe.Pointer(uintptr(0)),
+		isShuttingDown: uintptr(0),
 	}, nil
 }


### PR DESCRIPTION
This is an obvious error.  The unsafe.Pointer was intended to store a flag value (zero or non-zero) but it may well confuse the garbage collector.  See http://tip.golang.org/doc/go1.3#garbage_collector
