### PR TITLE
fix crash on x86-32

### DIFF
--- a/file_journal.go
+++ b/file_journal.go
@@ -53,6 +53,7 @@ type FileJournalChunkDequeue struct {
 }
 
 type FileJournalChunk struct {
+	Size      int64 // This variable must be on 64-bit alignment. Otherwise atomic.AddInt64 will cause a crash on ARM and x86-32
 	head      FileJournalChunkDequeueHead
 	container *FileJournalChunkDequeue
 	Path      string
@@ -60,7 +61,6 @@ type FileJournalChunk struct {
 	TSuffix   string
 	Timestamp int64
 	UniqueId  []byte
-	Size      int64
 	refcount  int32
 	mtx       sync.Mutex
 }

--- a/input.go
+++ b/input.go
@@ -40,6 +40,7 @@ type forwardClient struct {
 }
 
 type ForwardInput struct {
+	entries        int64  // This variable must be on 64-bit alignment. Otherwise atomic.AddInt64 will cause a crash on ARM and x86-32
 	port           Port
 	logger         *logging.Logger
 	bind           string
@@ -47,7 +48,6 @@ type ForwardInput struct {
 	codec          *codec.MsgpackHandle
 	clientsMtx     sync.Mutex
 	clients        map[*net.TCPConn]*forwardClient
-	entries        int64
 	wg             sync.WaitGroup
 	acceptChan     chan *net.TCPConn
 	shutdownChan   chan struct{}


### PR DESCRIPTION
When use atocim.AddInt64, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. 
https://golang.org/pkg/sync/atomic/#pkg-note-BUG

But, [`FileJournalChunk.Size`](https://github.com/fluent/fluentd-forwarder/blob/3fc5dac4fa721eebe27b5a0d513b97c685760afc/file_journal.go#L55) isn't on 64-bit alignment.
(The first word in a struct, it is on 64-bit aligned always.

```
byte from first word in a struct : variable name

 0: head      FileJournalChunkDequeueHead
 8: container *FileJournalChunkDequeue
12: Path      string                                         
20: Type      JournalFileType                         
24: TSuffix   string                                          
32: Timestamp int64                                 
40: UniqueId  []byte 
52: Size      int64
```

So, when execute on x86-32 environment(for example, using go windows/386),
this software will crash on [file_journal.go#L562](https://github.com/fluent/fluentd-forwarder/blob/3fc5dac4fa721eebe27b5a0d513b97c685760afc/file_journal.go#L562)

I move  this variable to first in struct.

Fortunately, [`ForwardInput.entries'](https://github.com/fluent/fluentd-forwarder/blob/3fc5dac4fa721eebe27b5a0d513b97c685760afc/input.go#L43) is on 64bit alignment which have same problem.
But, if we add some variable like uint32 to before the 'entries', this software will crash.
So, I move it to first too.
