### PR TITLE
Close reader

### DIFF
--- a/file_journal_test.go
+++ b/file_journal_test.go
@@ -485,6 +485,7 @@ func Test_Journal_FlushListener(t *testing.T) {
 		if err != nil {
 			t.FailNow()
 		}
+		defer reader.Close()
 		bytes, err := ioutil.ReadAll(reader)
 		if err != nil {
 			t.FailNow()


### PR DESCRIPTION
This fix test failing in Test_Journal_FlushListener I pointed in https://github.com/fluent/fluentd-forwarder/pull/10#issuecomment-102349775
But still failing:
```
--- FAIL: Test_Journal_Scanning_Ok (0.02s)
        file_journal_test.go:328: journal.chunks.count=1
        file_journal_test.go:329: journal.chunks.first.Size=8
        file_journal_test.go:341: journal.chunks.count=1
        file_journal_test.go:328: journal.chunks.count=2
        file_journal_test.go:329: journal.chunks.first.Size=8
        file_journal_test.go:341: journal.chunks.count=1
        file_journal_test.go:328: journal.chunks.count=3
        file_journal_test.go:329: journal.chunks.first.Size=8
        file_journal_test.go:341: journal.chunks.count=1
FAIL
exit status 1
FAIL    github.com/fluent/fluentd-forwarder     1.369s
```
