### PR TITLE
change github.com/treasure-data to github.com/fluent

### DIFF
--- a/entrypoints/fluentd_forwarder/main.go
+++ b/entrypoints/fluentd_forwarder/main.go
@@ -8,7 +8,7 @@ import (
 	strftime "github.com/jehiah/go-strftime"
 	ioextras "github.com/moriyoshi/go-ioextras"
 	logging "github.com/op/go-logging"
-	fluentd_forwarder "github.com/treasure-data/fluentd-forwarder"
+	fluentd_forwarder "github.com/fluent/fluentd-forwarder"
 	"io"
 	"io/ioutil"
 	"log"

--- a/entrypoints/fluentd_forwarder/signal.go
+++ b/entrypoints/fluentd_forwarder/signal.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	fluentd_forwarder "github.com/treasure-data/fluentd-forwarder"
+	fluentd_forwarder "github.com/fluent/fluentd-forwarder"
 	"os"
 	"os/signal"
 )


### PR DESCRIPTION
When we build fluentd, we need create 'build_fluentd_forwarder', so go command download `github.com/fluent/fluentd-forwarde`.

But, when execute build_fluentd_forwarder, go command download `github.com/treasure-data/fluentd-forwarder` (which redirect to fluent/fluentd-forwarde) and use it.
But there're same repository, so it's not good.
