### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.4
+
+before_install:
+  - go get github.com/ugorji/go/codec
+  - go get github.com/op/go-logging
+  - go get github.com/jehiah/go-strftime
+  - go get github.com/moriyoshi/go-ioextras
+  - go get code.google.com/p/gcfg
+  - go get github.com/treasure-data/td-client-go
+
+script:
+  - cd entrypoints/fluentd_forwarder && go build
+  - cd - && go test


### PR DESCRIPTION
I'm not sure for the role of `build_pluentd_forwarder`, but I added `.travis.yml` to build `fluentd_forwarder` and to run `go test`.

This `.travis.yml` will be run `go get` and `go test` like this on Travis:
https://travis-ci.org/cosmo0920/fluentd-forwarder/builds/69096446

And I noticed that this repository also depends `github.com/treasure-data/td-client-go`.
I'll send another pull request to fix README.md about this. 