### PR TITLE
Fix library dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ fluentd_forwarder depends on the following external libraries:
 * github.com/jehiah/go-strftime
 * github.com/moriyoshi/go-ioextras
 * gopkg.in/gcfg.v1
+* github.com/treasure-data/td-client-go
 
 License
 -------


### PR DESCRIPTION
`fluentd-forwarder` also depends `github.com/treasure-data/td-client-go`.
