### PR TITLE
Suppress warnings for `go get` from "code.google.com/p/gcfg".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - go get github.com/op/go-logging
   - go get github.com/jehiah/go-strftime
   - go get github.com/moriyoshi/go-ioextras
-  - go get code.google.com/p/gcfg
+  - go get gopkg.in/gcfg.v1
   - go get github.com/treasure-data/td-client-go
 
 script:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ fluentd_forwarder depends on the following external libraries:
 * github.com/op/go-logging
 * github.com/jehiah/go-strftime
 * github.com/moriyoshi/go-ioextras
-* code.google.com/p/gcfg
+* gopkg.in/gcfg.v1
 
 License
 -------

--- a/entrypoints/fluentd_forwarder/main.go
+++ b/entrypoints/fluentd_forwarder/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	gcfg "code.google.com/p/gcfg"
+	gcfg "gopkg.in/gcfg.v1"
 	"crypto/x509"
 	"flag"
 	"fmt"


### PR DESCRIPTION
This repository will move to "gopkg.in/gcfg.v1".