### PR TITLE
Fix logger function

### DIFF
--- a/entrypoints/fluentd_forwarder/main.go
+++ b/entrypoints/fluentd_forwarder/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	gcfg "gopkg.in/gcfg.v1"
 	"crypto/x509"
 	"flag"
 	"fmt"
+	fluentd_forwarder "github.com/fluent/fluentd-forwarder"
 	strftime "github.com/jehiah/go-strftime"
 	ioextras "github.com/moriyoshi/go-ioextras"
 	logging "github.com/op/go-logging"
-	fluentd_forwarder "github.com/fluent/fluentd-forwarder"
+	gcfg "gopkg.in/gcfg.v1"
 	"io"
 	"io/ioutil"
 	"log"
@@ -290,7 +290,7 @@ func main() {
 	logger := logging.MustGetLogger("fluentd-forwarder")
 	logging.SetLevel(params.LogLevel, "fluentd-forwarder")
 	if progVersion != "" {
-		logger.Info("Version %s starting...", progVersion)
+		logger.Infof("Version %s starting...", progVersion)
 	}
 
 	workerSet := fluentd_forwarder.NewWorkerSet()

--- a/file_journal.go
+++ b/file_journal.go
@@ -285,7 +285,7 @@ func (journal *FileJournal) notifyFlushListeners(chunk *FileJournalChunk) {
 	for _, listener := range journal.flushListeners {
 		err := listener.ChunkFlushed(journal.newChunkWrapper(chunk))
 		if err != nil {
-			journal.group.logger.Error("error occurred during notifying flush event: %s", err.Error())
+			journal.group.logger.Errorf("error occurred during notifying flush event: %s", err.Error())
 		}
 	}
 }
@@ -295,7 +295,7 @@ func (journal *FileJournal) notifyNewChunkListeners(chunk *FileJournalChunk) {
 	for _, listener := range journal.newChunkListeners {
 		err := listener.NewChunkCreated(journal.newChunkWrapper(chunk))
 		if err != nil {
-			journal.group.logger.Error("error occurred during notifying flush event: %s", err.Error())
+			journal.group.logger.Errorf("error occurred during notifying flush event: %s", err.Error())
 		}
 	}
 }
@@ -368,7 +368,7 @@ func (journal *FileJournal) Flush(visitor func(JournalChunk) interface{}) error 
 		return nil
 	}()
 	if dequeue != nil {
-		journal.group.logger.Debug("chunks to flush: %d", dequeue.count)
+		journal.group.logger.Debugf("chunks to flush: %d", dequeue.count)
 		type pair struct {
 			chunk     *FileJournalChunk
 			futureErr <-chan error
@@ -420,7 +420,7 @@ func (journal *FileJournal) Flush(visitor func(JournalChunk) interface{}) error 
 					}
 				}
 			}
-			journal.group.logger.Debug("errors=%d, chunks=%d", len(errors), dequeue.count)
+			journal.group.logger.Debugf("errors=%d, chunks=%d", len(errors), dequeue.count)
 			if len(errors) > 0 {
 				err = errors
 			}
@@ -759,7 +759,7 @@ func scanJournals(logger *logging.Logger, pathPrefix string, pathSuffix string) 
 			variablePortion := file[len(basename) : len(file)-len(pathSuffix)]
 			info, err := DecodeJournalPath(variablePortion)
 			if err != nil {
-				logger.Warning("Unexpected file under the designated directory space (%s) - %s", dirname, file)
+				logger.Warningf("Unexpected file under the designated directory space (%s) - %s", dirname, file)
 				continue
 			}
 			journalProto, ok := journals[info.Key]
@@ -865,7 +865,7 @@ func (factory *FileJournalGroupFactory) GetJournalGroup(path string, worker Work
 		chunk.Size = position
 		journal.writer = file
 	}
-	factory.logger.Info("Path %s is designated to Worker %s", path, worker.String())
+	factory.logger.Infof("Path %s is designated to Worker %s", path, worker.String())
 	factory.paths[path] = journalGroup
 	return journalGroup, nil
 }

--- a/input.go
+++ b/input.go
@@ -188,24 +188,24 @@ func (c *forwardClient) startHandling() {
 		defer func() {
 			err := c.conn.Close()
 			if err != nil {
-				c.logger.Debug("Close: %s", err.Error())
+				c.logger.Debugf("Close: %s", err.Error())
 			}
 			c.input.markDischarged(c)
 			c.input.wg.Done()
 		}()
-		c.input.logger.Info("Started handling connection from %s", c.conn.RemoteAddr().String())
+		c.input.logger.Infof("Started handling connection from %s", c.conn.RemoteAddr().String())
 		for {
 			recordSets, err := c.decodeEntries()
 			if err != nil {
 				err_, ok := err.(net.Error)
 				if ok {
 					if err_.Temporary() {
-						c.logger.Info("Temporary failure: %s", err_.Error())
+						c.logger.Infof("Temporary failure: %s", err_.Error())
 						continue
 					}
 				}
 				if err == io.EOF {
-					c.logger.Info("Client %s closed the connection", c.conn.RemoteAddr().String())
+					c.logger.Infof("Client %s closed the connection", c.conn.RemoteAddr().String())
 				} else {
 					c.logger.Error(err.Error())
 				}
@@ -220,14 +220,14 @@ func (c *forwardClient) startHandling() {
 				}
 			}
 		}
-		c.input.logger.Info("Ended handling connection from %s", c.conn.RemoteAddr().String())
+		c.input.logger.Infof("Ended handling connection from %s", c.conn.RemoteAddr().String())
 	}()
 }
 
 func (c *forwardClient) shutdown() {
 	err := c.conn.Close()
 	if err != nil {
-		c.input.logger.Info("Error during closing connection: %s", err.Error())
+		c.input.logger.Infof("Error during closing connection: %s", err.Error())
 	}
 }
 
@@ -259,7 +259,7 @@ func (input *ForwardInput) spawnAcceptor() {
 				break
 			}
 			if conn != nil {
-				input.logger.Notice("Connected from %s", conn.RemoteAddr().String())
+				input.logger.Noticef("Connected from %s", conn.RemoteAddr().String())
 				input.acceptChan <- conn
 			} else {
 				input.logger.Notice("AcceptTCP returned nil; something went wrong")
@@ -336,12 +336,12 @@ func NewForwardInput(logger *logging.Logger, bind string, port Port) (*ForwardIn
 	_codec.RawToString = false
 	addr, err := net.ResolveTCPAddr("tcp", bind)
 	if err != nil {
-		logger.Error("%s", err.Error())
+		logger.Error(err.Error())
 		return nil, err
 	}
 	listener, err := net.ListenTCP("tcp", addr)
 	if err != nil {
-		logger.Error("%s", err.Error())
+		logger.Error(err.Error())
 		return nil, err
 	}
 	return &ForwardInput{


### PR DESCRIPTION
before(currently)
```
yuzuki:fluentd_forwarder yuzuki$ ./fluentd_forwarder
[fluentd-forwarder] 2016/03/18 12:29:07.566855 Unexpected file under the designated directory space (%s) - %s . fluentd_forwarder
[fluentd-forwarder] 2016/03/18 12:29:07.566879 Unexpected file under the designated directory space (%s) - %s . main.go
[fluentd-forwarder] 2016/03/18 12:29:07.566884 Unexpected file under the designated directory space (%s) - %s . signal.go
[fluentd-forwarder] 2016/03/18 12:29:07.566913 Path %s is designated to Worker %s * output
[fluentd-forwarder] 2016/03/18 12:29:07.567117 Spawning acceptor
[fluentd-forwarder] 2016/03/18 12:29:07.567132 Spawning daemon
[fluentd-forwarder] 2016/03/18 12:29:07.567140 Spawning spooler
[fluentd-forwarder] 2016/03/18 12:29:07.567144 Spawning emitter
[fluentd-forwarder] 2016/03/18 12:29:07.567182 Emitter started
[fluentd-forwarder] 2016/03/18 12:29:07.567249 Daemon started
[fluentd-forwarder] 2016/03/18 12:29:07.567310 Spooler started
[fluentd-forwarder] 2016/03/18 12:29:07.567315 Acceptor started
^C[fluentd-forwarder] 2016/03/18 12:29:08.916666 Daemon ended
[fluentd-forwarder] 2016/03/18 12:29:08.916693 Emitter ended
[fluentd-forwarder] 2016/03/18 12:29:08.916705 Spooler ended
[fluentd-forwarder] 2016/03/18 12:29:08.916882 accept tcp 127.0.0.1:24224: use of closed network connection
[fluentd-forwarder] 2016/03/18 12:29:08.916892 Acceptor ended
[fluentd-forwarder] 2016/03/18 12:29:08.916902 Shutting down...
yuzuki:fluentd_forwarder yuzuki$
```

after
```
yuzuki:fluentd_forwarder yuzuki$ ./fluentd_forwarder
[fluentd-forwarder] 2016/03/18 12:30:54.003065 Unexpected file under the designated directory space (.) - fluentd_forwarder
[fluentd-forwarder] 2016/03/18 12:30:54.003083 Unexpected file under the designated directory space (.) - main.go
[fluentd-forwarder] 2016/03/18 12:30:54.003088 Unexpected file under the designated directory space (.) - signal.go
[fluentd-forwarder] 2016/03/18 12:30:54.003112 Path * is designated to Worker output
[fluentd-forwarder] 2016/03/18 12:30:54.003284 Spawning acceptor
[fluentd-forwarder] 2016/03/18 12:30:54.003300 Spawning daemon
[fluentd-forwarder] 2016/03/18 12:30:54.003305 Spawning spooler
[fluentd-forwarder] 2016/03/18 12:30:54.003307 Spawning emitter
[fluentd-forwarder] 2016/03/18 12:30:54.003334 Emitter started
[fluentd-forwarder] 2016/03/18 12:30:54.003399 Acceptor started
[fluentd-forwarder] 2016/03/18 12:30:54.003450 Daemon started
[fluentd-forwarder] 2016/03/18 12:30:54.003557 Spooler started
^C[fluentd-forwarder] 2016/03/18 12:30:55.175680 Daemon ended
[fluentd-forwarder] 2016/03/18 12:30:55.175853 Emitter ended
[fluentd-forwarder] 2016/03/18 12:30:55.175873 Spooler ended
[fluentd-forwarder] 2016/03/18 12:30:55.175874 accept tcp 127.0.0.1:24224: use of closed network connection
[fluentd-forwarder] 2016/03/18 12:30:55.175894 Acceptor ended
[fluentd-forwarder] 2016/03/18 12:30:55.175905 Shutting down...
yuzuki:fluentd_forwarder yuzuki$
```