### PR TITLE
Support int64 timestamps

### DIFF
--- a/input.go
+++ b/input.go
@@ -112,6 +112,27 @@ func (c *forwardClient) decodeEntries() ([]FluentRecordSet, error) {
 
 	var retval []FluentRecordSet
 	switch timestamp_or_entries := v[1].(type) {
+	case int64:
+		timestamp := timestamp_or_entries
+		if timestamp < 0 {
+			return nil, errors.New(fmt.Sprintf("Invalid timestamp: %t", timestamp_or_entries))
+		}
+		data, ok := v[2].(map[string]interface{})
+		if !ok {
+			return nil, errors.New("Failed to decode data field")
+		}
+		coerceInPlace(data)
+		retval = []FluentRecordSet{
+			{
+				Tag: string(tag), // XXX: byte => rune
+				Records: []TinyFluentRecord{
+					{
+						Timestamp: uint64(timestamp),
+						Data:      data,
+					},
+				},
+			},
+		}
 	case uint64:
 		timestamp := timestamp_or_entries
 		data, ok := v[2].(map[string]interface{})


### PR DESCRIPTION
The codec decoder decides what type to do based on reflection etc.
which doesn't gaurantee that we'll get the type we want (since we are
decoding into an empty interface).

The golang fluent-logger client
(https://github.com/fluent/fluent-logger-golang) sends the timestamps as
int64 (not uint64) -- which was causing errors about "Unknown type".

This patch allows the codec decoder to pick the type it wants and we'll do
validation on it-- specifically if it is an int64 we coerce it to uint64
-- logging an error if the value given to us was negative (since we
can't convert, and a negative timestamp is just generally considered
wrong)